### PR TITLE
Fix issues converting React code

### DIFF
--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`should handle class extends 1`] = `
 "declare class extension {
   getString(): string;
 }
-declare class extender mixins extension {
+declare class extender extends extension {
   getNumber(): number;
 }
 "
@@ -29,7 +29,7 @@ declare interface implementation2 {
 }
 declare class extension {}
 declare class implementor
-  mixins extension
+  extends extension
   implements implementation1, implementation2
 {
   getString(): string;
@@ -41,7 +41,7 @@ declare class implementor
 exports[`should handle static methods ES6 classes 1`] = `
 "declare class Subscribable<T> {}
 declare class Operator<T, R> {}
-declare class Observable<T> mixins Subscribable<T> {
+declare class Observable<T> extends Subscribable<T> {
   create: Function;
   static create: Function;
   lift<R>(operator: Operator<T, R>): Observable<R>;

--- a/src/__tests__/__snapshots__/global-this.spec.ts.snap
+++ b/src/__tests__/__snapshots__/global-this.spec.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`should not crash when getting globalThis in code 1`] = `
 "import * as React from \\"react\\";
-declare export default class MenuStatefulContainer mixins React.Component<> {
-  handleItemClick: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+declare export default class MenuStatefulContainer extends React.Component<> {
+  handleItemClick: (event: SyntheticMouseEvent<HTMLElement>) => void;
   render(): React.Node;
 }
 "

--- a/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/module-identifiers.spec.ts.snap
@@ -7,7 +7,7 @@ declare type Props = {
   children: React$Node,
   ...
 };
-declare class Component mixins React.Component<Props> {
+declare class Component extends React.Component<Props> {
   render(): React$Node;
 }
 "
@@ -18,6 +18,7 @@ exports[`should handle react types 1`] = `
 import * as React from \\"react\\";
 declare function s(node: Node): void;
 declare function s(node: React.Node): void;
+declare function s(node: React.Element<any>): void;
 declare function s(node: Element<\\"div\\">): void;
 declare function s(node: React.Element<\\"div\\">): void;
 "

--- a/src/__tests__/__snapshots__/namespaces.spec.ts.snap
+++ b/src/__tests__/__snapshots__/namespaces.spec.ts.snap
@@ -280,7 +280,7 @@ declare class A$B$D<S> {}
 declare var npm$namespace$A$B$C: {|
   N: typeof A$B$C$N,
 |};
-declare class A$B$C$N<A> mixins A$B$D<A> implements A$B$S<A> {
+declare class A$B$C$N<A> extends A$B$D<A> implements A$B$S<A> {
   a: string;
 }
 "

--- a/src/__tests__/module-identifiers.spec.ts
+++ b/src/__tests__/module-identifiers.spec.ts
@@ -7,11 +7,52 @@ import type {ReactNode, ReactElement} from 'react'
 import * as React from 'react'
 declare function s(node: ReactNode): void;
 declare function s(node: React.ReactNode): void;
+declare function s(node: React.ReactElement): void;
 declare function s(node: ReactElement<'div'>): void;
 declare function s(node: React.ReactElement<'div'>): void;
 `;
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle react event types", () => {
+  const ts = `
+import * as React from 'react'
+declare function s(event: React.MouseEvent): void;
+declare function s(event: React.TouchEvent): void;
+declare function s(event: React.KeyboardEvent): void;
+declare function s(event: React.FocusEvent): void;
+declare function s(event: React.SyntheticEvent): void;
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "import * as React from \\"react\\";
+    declare function s(event: SyntheticMouseEvent<>): void;
+    declare function s(event: SyntheticTouchEvent<>): void;
+    declare function s(event: SyntheticKeyboardEvent<>): void;
+    declare function s(event: SyntheticFocusEvent<>): void;
+    declare function s(event: SyntheticEvent<>): void;
+    "
+  `);
+  expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle other react types", () => {
+  const ts = `
+import * as React from 'react'
+class MyComponent extends React.Component<{}> {}
+declare const FuncComp: React.FC<Props>;
+declare type Props = React.ComponentProps<typeof MyComponent>;
+`;
+  const result = compiler.compileDefinitionString(ts, { quiet: true });
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "import * as React from \\"react\\";
+    declare class MyComponent extends React.Component<{ ... }> {}
+    declare var FuncComp: React.StatelessFunctionalComponent<Props>;
+    declare type Props = React.ElementProps<typeof MyComponent>;
+    "
+  `);
   expect(result).toBeValidFlowTypeDeclarations();
 });
 

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -339,7 +339,7 @@ export const classDeclaration = <T>(
       clause.types.forEach(classHeritageClause(classMixins, classImplements));
     });
     const mixinsMessage =
-      classMixins.length > 0 ? `mixins ${classMixins.join(",")}` : "";
+      classMixins.length > 0 ? `extends ${classMixins.join(",")}` : "";
     const classImplementsMessage =
       classImplements.length > 0
         ? ` implements ${classImplements.join(",")}`

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -62,6 +62,28 @@ const setGlobalName = (
   return false;
 };
 
+const eventTypes = {
+  SyntheticEvent: "SyntheticEvent",
+  AnimationEvent: "SyntheticAnimationEvent",
+  CompositionEvent: "SyntheticCompositionEvent",
+  ClipboardEvent: "SyntheticClipboardEvent",
+  UIEvent: "SyntheticUIEvent",
+  FocusEvent: "SyntheticFocusEvent",
+  KeyboardEvent: "SyntheticKeyboardEvent",
+  MouseEvent: "SyntheticMouseEvent",
+  DragEvent: "SyntheticDragEvent",
+  WheelEvent: "SyntheticWheelEvent",
+  PointerEvent: "SyntheticPointerEvent",
+  TouchEvent: "SyntheticTouchEvent",
+  TransitionEvent: "SyntheticTransitionEvent",
+};
+
+const reactTypes = {
+  ComponentType: "FragmentType",
+  ComponentProps: "ElementProps",
+  FC: "StatelessFunctionalComponent",
+};
+
 export function renames(
   symbol: ts.Symbol | void,
   type: ts.TypeReferenceNode | ts.ImportSpecifier,
@@ -82,6 +104,37 @@ export function renames(
       }
     }
     if (ts.isQualifiedName(type.typeName)) {
+      const left = type.typeName.left.getText(); // ?
+      const right = type.typeName.right.getText(); // ?
+
+      if (left === "React") {
+        if (right in eventTypes) {
+          // React's TypeScript event types can take two type params, but
+          // Flow's can only take one.
+          if (type.typeArguments.length === 2) {
+            // We only need the first one, so we remove the second one.
+            // @ts-expect-error: typeArguments is supposed to be readonly
+            type.typeArguments.pop();
+          }
+          // @ts-expect-error: typeName is supposed to be readonly
+          type.typeName = ts.createIdentifier(eventTypes[right]);
+          return true;
+        }
+
+        if (right in reactTypes) {
+          // @ts-expect-error: typeName is supposed to be readonly
+          type.typeName.right.escapedText = reactTypes[right];
+          return true;
+        }
+      }
+
+      if (left === "React" && right === "ReactElement") {
+        if (type.typeArguments.length === 0) {
+          // @ts-expect-error: typeArguments is supposed to be readonly
+          type.typeArguments = [{ kind: ts.SyntaxKind.AnyKeyword }];
+        }
+      }
+
       return setImportedName(
         symbol.escapedName,
         type.typeName.right,

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -104,8 +104,8 @@ export function renames(
       }
     }
     if (ts.isQualifiedName(type.typeName)) {
-      const left = type.typeName.left.getText(); // ?
-      const right = type.typeName.right.getText(); // ?
+      const left = type.typeName.left.getText();
+      const right = type.typeName.right.getText();
 
       if (left === "React") {
         if (right in eventTypes) {


### PR DESCRIPTION
## Summary:
This PR fixes a number of issues that I noticed when attempting to update wonder-blocks deps in webapp after converting them to TS.  This PR fixes the following issues:
- event types are converted properly now
- a couple of commonly used React types are converted properly now
- `extends` is used instead of `mixins`
- ensures `React.Element<>` has a type parameter

Issue: None

## Test plan:
- yarn test