### PR TITLE
Fix issue with implements clause and imported interfaces

### DIFF
--- a/lib/printers/declarations.js
+++ b/lib/printers/declarations.js
@@ -138,8 +138,8 @@ const interfaceRecordType = (node, heritage, withSemicolons = false) => {
   }
 };
 
-const classHeritageClause = (classMixins, classImplements) => (0, _env.withEnv)((env, type) => {
-  env.classHeritage = true; // TODO: refactor this
+const classHeritageClause = classHeritageTypes => (0, _env.withEnv)((env, type) => {
+  env.classHeritage = true;
 
   const symbol = _checker.checker.current.getSymbolAtLocation(type.expression);
 
@@ -147,14 +147,9 @@ const classHeritageClause = (classMixins, classImplements) => (0, _env.withEnv)(
 
   if (ts.isIdentifier(type.expression) && symbol) {
     const value = printers.node.getFullyQualifiedPropertyAccessExpression(symbol, type.expression) + printers.common.generics(type.typeArguments);
-
-    if (symbol.declarations.some(declaration => declaration.kind === ts.SyntaxKind.InterfaceDeclaration)) {
-      classImplements.push(value);
-    } else {
-      classMixins.push(value);
-    }
+    classHeritageTypes.push(value);
   } else {
-    classMixins.push(printers.node.printType(type));
+    classHeritageTypes.push(printers.node.printType(type));
   }
 
   env.classHeritage = false;
@@ -280,7 +275,11 @@ const classDeclaration = (nodeName, node, mergedNamespaceChildren) => {
     const classMixins = [];
     const classImplements = [];
     node.heritageClauses.forEach(clause => {
-      clause.types.forEach(classHeritageClause(classMixins, classImplements));
+      if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
+        clause.types.forEach(classHeritageClause(classMixins));
+      } else if (clause.token === ts.SyntaxKind.ImplementsKeyword) {
+        clause.types.forEach(classHeritageClause(classImplements));
+      }
     });
     const mixinsMessage = classMixins.length > 0 ? `extends ${classMixins.join(",")}` : "";
     const classImplementsMessage = classImplements.length > 0 ? ` implements ${classImplements.join(",")}` : "";

--- a/src/__tests__/__snapshots__/classes.spec.ts.snap
+++ b/src/__tests__/__snapshots__/classes.spec.ts.snap
@@ -39,9 +39,9 @@ declare class implementor
 `;
 
 exports[`should handle static methods ES6 classes 1`] = `
-"declare class Subscribable<T> {}
+"declare interface Subscribable<T> {}
 declare class Operator<T, R> {}
-declare class Observable<T> extends Subscribable<T> {
+declare class Observable<T> implements Subscribable<T> {
   create: Function;
   static create: Function;
   lift<R>(operator: Operator<T, R>): Observable<R>;

--- a/src/__tests__/classes.spec.ts
+++ b/src/__tests__/classes.spec.ts
@@ -3,7 +3,7 @@ import "../test-matchers";
 
 it("should handle static methods ES6 classes", () => {
   const ts = `
-  class Subscribable<T> {}
+  interface Subscribable<T> {}
   class Operator<T, R> {}
   class Observable<T> implements Subscribable<T> {
     create: Function;
@@ -75,4 +75,45 @@ it("should handle class implements and extends", () => {
   const result = compiler.compileDefinitionString(ts, { quiet: true });
   expect(beautify(result)).toMatchSnapshot();
   expect(result).toBeValidFlowTypeDeclarations();
+});
+
+it("should handle class implements and extends with an imported interface", () => {
+  const ts = `
+  import * as React from "react";
+  import type {Implementation1} from "../foo";
+  type Props = {
+    msg: string,
+  }
+  type State = {
+    count: number,
+  }
+  export default class TooltipAnchor extends React.Component<Props, State> implements Implementation1 {
+    getString(): string
+  }
+  `;
+  const result = compiler.compileDefinitionString(ts, {
+    quiet: true,
+    inexact: false,
+    jsdoc: true,
+  });
+  expect(beautify(result)).toMatchInlineSnapshot(`
+    "import * as React from \\"react\\";
+    import type { Implementation1 } from \\"../foo\\";
+    declare type Props = {|
+      msg: string,
+    |};
+    declare type State = {|
+      count: number,
+    |};
+    declare export default class TooltipAnchor
+      extends React.Component<Props, State>
+      implements Implementation1
+    {
+      getString(): string;
+    }
+    "
+  `);
+  // NOTE: We don't bother calling .toBeValidFlowTypeDeclarations() because there
+  // instead a way for types to be imported from other files with the way this
+  // test harness is set up.
 });

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -151,7 +151,6 @@ const classHeritageClause = (classHeritageTypes: string[]) =>
   withEnv<{ classHeritage?: boolean }, [ts.ExpressionWithTypeArguments], void>(
     (env, type) => {
       env.classHeritage = true;
-      // TODO: refactor this
       const symbol = checker.current.getSymbolAtLocation(type.expression);
       printers.node.fixDefaultTypeArguments(symbol, type);
       if (ts.isIdentifier(type.expression) && symbol) {

--- a/src/printers/declarations.ts
+++ b/src/printers/declarations.ts
@@ -147,10 +147,7 @@ const interfaceRecordType = (
   }
 };
 
-const classHeritageClause = (
-  classMixins: string[],
-  classImplements: string[],
-) =>
+const classHeritageClause = (classHeritageTypes: string[]) =>
   withEnv<{ classHeritage?: boolean }, [ts.ExpressionWithTypeArguments], void>(
     (env, type) => {
       env.classHeritage = true;
@@ -163,18 +160,9 @@ const classHeritageClause = (
             symbol,
             type.expression,
           ) + printers.common.generics(type.typeArguments);
-        if (
-          symbol.declarations.some(
-            declaration =>
-              declaration.kind === ts.SyntaxKind.InterfaceDeclaration,
-          )
-        ) {
-          classImplements.push(value);
-        } else {
-          classMixins.push(value);
-        }
+        classHeritageTypes.push(value);
       } else {
-        classMixins.push(printers.node.printType(type));
+        classHeritageTypes.push(printers.node.printType(type));
       }
       env.classHeritage = false;
     },
@@ -336,7 +324,11 @@ export const classDeclaration = <T>(
     const classMixins = [];
     const classImplements = [];
     node.heritageClauses.forEach(clause => {
-      clause.types.forEach(classHeritageClause(classMixins, classImplements));
+      if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
+        clause.types.forEach(classHeritageClause(classMixins));
+      } else if (clause.token === ts.SyntaxKind.ImplementsKeyword) {
+        clause.types.forEach(classHeritageClause(classImplements));
+      }
     });
     const mixinsMessage =
       classMixins.length > 0 ? `extends ${classMixins.join(",")}` : "";


### PR DESCRIPTION
## Summary:
The logic that flowgen was using to determine whether a heritage clause was an 'extends' or a 'implements' clause was faulty.  I've refactor it to look at clause.token which contains either an 'extends' or 'implements' token.  This simplify the code a bunch and fixed the issue that the tool was running into in wonder-blocks where it thought something part of the 'extends' clause when actually it was part of the 'implements' clause.

Issue: None

## Test plan:
- yarn test