### PR TITLE
Convert ForwardedRef and ForwardRefExoticComponent

### DIFF
--- a/lib/printers/smart-identifiers.js
+++ b/lib/printers/smart-identifiers.js
@@ -90,10 +90,69 @@ const eventTypes = {
 };
 const reactTypes = {
   ComponentProps: "ElementProps",
-  FC: "StatelessFunctionalComponent"
+  FC: "StatelessFunctionalComponent",
+  ForwardedRef: "Ref"
 };
 
 function renames(symbol, type) {
+  console.log("renames");
+  console.log(!symbol);
+
+  if (type.kind === ts.SyntaxKind.TypeReference && ts.isQualifiedName(type.typeName)) {
+    const left = type.typeName.left.getText();
+    const right = type.typeName.right.getText();
+
+    if (left === "React") {
+      if (right in eventTypes) {
+        // React's TypeScript event types can take two type params, but
+        // Flow's can only take one.
+        if (type.typeArguments.length === 2) {
+          // We only need the first one, so we remove the second one.
+          // @ts-expect-error: typeArguments is supposed to be readonly
+          type.typeArguments.pop();
+        } // @ts-expect-error: typeName is supposed to be readonly
+
+
+        type.typeName = ts.createIdentifier(eventTypes[right]);
+        return true;
+      }
+
+      if (right in reactTypes) {
+        // @ts-expect-error: typeName is supposed to be readonly
+        type.typeName.right.escapedText = reactTypes[right];
+        return true;
+      }
+    }
+
+    if (left === "React" && right === "ForwardRefExoticComponent") {
+      const typeArg = type.typeArguments[0];
+
+      if (ts.isIntersectionTypeNode(typeArg)) {
+        const [props, maybeRefAttributes] = typeArg.types;
+
+        if (ts.isTypeReferenceNode(maybeRefAttributes) && ts.isQualifiedName(maybeRefAttributes.typeName)) {
+          const left = maybeRefAttributes.typeName.left.getText();
+          const right = maybeRefAttributes.typeName.right.getText();
+
+          if (left === "React" && right === "RefAttributes" && maybeRefAttributes.typeArguments) {
+            const instance = maybeRefAttributes.typeArguments[0]; // @ts-expect-error: typeArguments is supposed to be readonly
+
+            type.typeArguments = [props, instance]; // @ts-expect-error: typeName is supposed to be readonly
+
+            type.typeName.right.escapedText = "AbstractComponent";
+            return true;
+          }
+        }
+      } else if (typeArg.kind === ts.SyntaxKind.AnyKeyword) {
+        // @ts-expect-error: typeArguments is supposed to be readonly
+        type.typeArguments = [ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword), ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)]; // @ts-expect-error: typeName is supposed to be readonly
+
+        type.typeName.right.escapedText = "AbstractComponent";
+        return true;
+      }
+    }
+  }
+
   if (!symbol) return false;
   if (!symbol.declarations) return false;
   const decl = symbol.declarations[0];
@@ -119,28 +178,6 @@ function renames(symbol, type) {
     if (ts.isQualifiedName(type.typeName)) {
       const left = type.typeName.left.getText();
       const right = type.typeName.right.getText();
-
-      if (left === "React") {
-        if (right in eventTypes) {
-          // React's TypeScript event types can take two type params, but
-          // Flow's can only take one.
-          if (type.typeArguments.length === 2) {
-            // We only need the first one, so we remove the second one.
-            // @ts-expect-error: typeArguments is supposed to be readonly
-            type.typeArguments.pop();
-          } // @ts-expect-error: typeName is supposed to be readonly
-
-
-          type.typeName = ts.createIdentifier(eventTypes[right]);
-          return true;
-        }
-
-        if (right in reactTypes) {
-          // @ts-expect-error: typeName is supposed to be readonly
-          type.typeName.right.escapedText = reactTypes[right];
-          return true;
-        }
-      }
 
       if (left === "React" && right === "ReactElement") {
         if (type.typeArguments.length === 0) {

--- a/src/__tests__/react-types.spec.ts
+++ b/src/__tests__/react-types.spec.ts
@@ -1,0 +1,67 @@
+import { compiler, beautify } from "..";
+import "../test-matchers";
+
+describe("React types", () => {
+  test("React.MouseEvent should become React.SyntheticMouseEvent", () => {
+    const ts = `import * as React from "react";
+declare const event: React.MouseEvent<HTMLButtonElement>;
+`;
+
+    const result = compiler.compileDefinitionString(ts);
+    expect(beautify(result)).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+      declare var event: SyntheticMouseEvent<HTMLButtonElement>;
+      "
+    `);
+    expect(result).toBeValidFlowTypeDeclarations();
+  });
+
+  test("React.ReactNode should become React.Node", () => {
+    const ts = `import * as React from "react";
+declare const Foo: () => React.ReactNode;
+`;
+
+    const result = compiler.compileDefinitionString(ts);
+    expect(beautify(result)).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+      declare var Foo: () => React.Node;
+      "
+    `);
+    expect(result).toBeValidFlowTypeDeclarations();
+  });
+
+  test("React.ForwardRefExoticComponent should become React.AbstractComponent", () => {
+    const ts = `import * as React from "react";
+type ExportProps = {msg: string};
+declare const Foo: React.ForwardRefExoticComponent<ExportProps & React.RefAttributes<HTMLInputElement>>;
+declare const Bar: React.ForwardRefExoticComponent<any>;
+`;
+
+    const result = compiler.compileDefinitionString(ts, { inexact: false });
+    expect(beautify(result)).toMatchInlineSnapshot(`
+      "import * as React from \\"react\\";
+      declare type ExportProps = {|
+        msg: string,
+      |};
+      declare var Foo: React.AbstractComponent<ExportProps, HTMLInputElement>;
+      declare var Bar: React.AbstractComponent<any, any>;
+      "
+    `);
+    expect(result).toBeValidFlowTypeDeclarations();
+  });
+
+  test("React.ForwardedRef should become React.Ref", () => {
+    const ts = `type WithForwardRef = {
+    forwardedRef: React.ForwardedRef<HTMLInputElement>;
+};`;
+
+    const result = compiler.compileDefinitionString(ts, { inexact: false });
+    expect(beautify(result)).toMatchInlineSnapshot(`
+      "declare type WithForwardRef = {|
+        forwardedRef: React$Ref<HTMLInputElement>,
+      |};
+      "
+    `);
+    expect(result).toBeValidFlowTypeDeclarations();
+  });
+});


### PR DESCRIPTION
## Summary:
These types weren't being converted and they aren't valid Flow types.  Flow was ignoring these errors in the lib defs for soem reason.  I've added code to convert these types and the tests verify that the generated types are indeed valid Flow types.

Issue: None

## Test plan:
- yarn test