### PR TITLE
Update React.ForwardedRef<T> conversion to handle no component refs

### DIFF
--- a/lib/printers/node.js
+++ b/lib/printers/node.js
@@ -532,16 +532,16 @@ const printType = (0, _env.withEnv)((env, rawType) => {
           symbol = _checker.checker.current.getSymbolAtLocation(type.typeName); //$todo
 
           fixDefaultTypeArguments(symbol, type);
-          const isRenamedOrReplaceWithNode = (0, _smartIdentifiers.renames)(symbol, type);
+          const isRenamedOrReplacedNode = (0, _smartIdentifiers.renamesOrReplacesNode)(symbol, type);
 
-          if (!isRenamedOrReplaceWithNode) {
+          if (!isRenamedOrReplacedNode) {
             //$todo weird union errors
             // @ts-expect-error todo(flow->ts)
             type.typeName.escapedText = getFullyQualifiedName(symbol, type.typeName);
           }
 
-          if (typeof isRenamedOrReplaceWithNode !== "boolean") {
-            return printType(isRenamedOrReplaceWithNode);
+          if (typeof isRenamedOrReplacedNode !== "boolean") {
+            return printType(isRenamedOrReplacedNode);
           }
 
           const getAdjustedType = targetSymbol => {
@@ -700,7 +700,7 @@ const printType = (0, _env.withEnv)((env, rawType) => {
         //$todo some weird union errors
         const symbol = _checker.checker.current.getSymbolAtLocation(type.name);
 
-        (0, _smartIdentifiers.renames)(symbol, type);
+        (0, _smartIdentifiers.renamesOrReplacesNode)(symbol, type);
       }
 
       return printers.relationships.importExportSpecifier(type);

--- a/lib/printers/node.js
+++ b/lib/printers/node.js
@@ -532,12 +532,16 @@ const printType = (0, _env.withEnv)((env, rawType) => {
           symbol = _checker.checker.current.getSymbolAtLocation(type.typeName); //$todo
 
           fixDefaultTypeArguments(symbol, type);
-          const isRenamed = (0, _smartIdentifiers.renames)(symbol, type);
+          const isRenamedOrReplaceWithNode = (0, _smartIdentifiers.renames)(symbol, type);
 
-          if (!isRenamed) {
+          if (!isRenamedOrReplaceWithNode) {
             //$todo weird union errors
             // @ts-expect-error todo(flow->ts)
             type.typeName.escapedText = getFullyQualifiedName(symbol, type.typeName);
+          }
+
+          if (typeof isRenamedOrReplaceWithNode !== "boolean") {
+            return printType(isRenamedOrReplaceWithNode);
           }
 
           const getAdjustedType = targetSymbol => {

--- a/lib/printers/smart-identifiers.js
+++ b/lib/printers/smart-identifiers.js
@@ -90,8 +90,8 @@ const eventTypes = {
 };
 const reactTypes = {
   ComponentProps: "ElementProps",
-  FC: "StatelessFunctionalComponent",
-  ForwardedRef: "Ref"
+  FC: "StatelessFunctionalComponent" // ForwardedRef: "Ref",
+
 };
 
 function renames(symbol, type) {
@@ -118,6 +118,18 @@ function renames(symbol, type) {
         // @ts-expect-error: typeName is supposed to be readonly
         type.typeName.right.escapedText = reactTypes[right];
         return true;
+      }
+    }
+
+    if (left === "React" && right === "ForwardedRef") {
+      const typeArg = type.typeArguments[0];
+      const {
+        parent
+      } = type;
+
+      if (ts.isPropertySignature(parent)) {
+        return ts.createTypeLiteralNode([ts.createPropertySignature([], "current", undefined, ts.createUnionTypeNode([typeArg, // @ts-expect-error: createKeywordTypeNode doesn't like being passed NullKeyword
+        ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword)]))]);
       }
     }
 

--- a/lib/printers/smart-identifiers.js
+++ b/lib/printers/smart-identifiers.js
@@ -2,7 +2,7 @@
 
 exports.__esModule = true;
 exports.getLeftMostEntityName = getLeftMostEntityName;
-exports.renames = renames;
+exports.renamesOrReplacesNode = renamesOrReplacesNode;
 
 var ts = _interopRequireWildcard(require("typescript"));
 
@@ -90,11 +90,11 @@ const eventTypes = {
 };
 const reactTypes = {
   ComponentProps: "ElementProps",
-  FC: "StatelessFunctionalComponent" // ForwardedRef: "Ref",
+  FC: "StatelessFunctionalComponent"
+}; // This function will either rename the node or, if it's React.ForwardedRef<T> it
+// will return a new node containing the type literal {current: T | null}.
 
-};
-
-function renames(symbol, type) {
+function renamesOrReplacesNode(symbol, type) {
   if (type.kind === ts.SyntaxKind.TypeReference && ts.isQualifiedName(type.typeName)) {
     const left = type.typeName.left.getText();
     const right = type.typeName.right.getText();
@@ -120,6 +120,15 @@ function renames(symbol, type) {
         return true;
       }
     }
+    /**
+     * Convert React.ForwardRef<T> to {|current: T | null|}
+     *
+     * NOTE(kevinb): We can't output {|current: ?T|} because the TypeScript
+     * AST doesn't have a nullable operator and the way Flowgen works
+     * is that it operators on a TS AST and then has a printer which
+     * does the final conversion to Flow syntax.
+     */
+
 
     if (left === "React" && right === "ForwardedRef") {
       const typeArg = type.typeArguments[0];

--- a/src/__tests__/react-types.spec.ts
+++ b/src/__tests__/react-types.spec.ts
@@ -50,7 +50,7 @@ declare const Bar: React.ForwardRefExoticComponent<any>;
     expect(result).toBeValidFlowTypeDeclarations();
   });
 
-  test("React.ForwardedRef should become React.Ref", () => {
+  test("React.ForwardedRef should become {|current: T | null|}", () => {
     const ts = `type WithForwardRef = {
     forwardedRef: React.ForwardedRef<HTMLInputElement>;
 };`;
@@ -58,7 +58,9 @@ declare const Bar: React.ForwardRefExoticComponent<any>;
     const result = compiler.compileDefinitionString(ts, { inexact: false });
     expect(beautify(result)).toMatchInlineSnapshot(`
       "declare type WithForwardRef = {|
-        forwardedRef: React$Ref<HTMLInputElement>,
+        forwardedRef: {|
+          current: HTMLInputElement | null,
+        |},
       |};
       "
     `);

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -623,14 +623,18 @@ export const printType = withEnv<any, [any], string>(
 
           //$todo
           fixDefaultTypeArguments(symbol, type);
-          const isRenamed = renames(symbol, type);
-          if (!isRenamed) {
+          const isRenamedOrReplaceWithNode = renames(symbol, type);
+          if (!isRenamedOrReplaceWithNode) {
             //$todo weird union errors
             // @ts-expect-error todo(flow->ts)
             type.typeName.escapedText = getFullyQualifiedName(
               symbol,
               type.typeName,
             );
+          }
+
+          if (typeof isRenamedOrReplaceWithNode !== "boolean") {
+            return printType(isRenamedOrReplaceWithNode);
           }
 
           const getAdjustedType = targetSymbol => {

--- a/src/printers/node.ts
+++ b/src/printers/node.ts
@@ -5,7 +5,10 @@ import * as printers from "./index";
 import { checker } from "../checker";
 import * as logger from "../logger";
 import { withEnv } from "../env";
-import { renames, getLeftMostEntityName } from "./smart-identifiers";
+import {
+  renamesOrReplacesNode,
+  getLeftMostEntityName,
+} from "./smart-identifiers";
 import { printErrorMessage } from "../errors/error-message";
 import { opts } from "../options";
 
@@ -623,8 +626,8 @@ export const printType = withEnv<any, [any], string>(
 
           //$todo
           fixDefaultTypeArguments(symbol, type);
-          const isRenamedOrReplaceWithNode = renames(symbol, type);
-          if (!isRenamedOrReplaceWithNode) {
+          const isRenamedOrReplacedNode = renamesOrReplacesNode(symbol, type);
+          if (!isRenamedOrReplacedNode) {
             //$todo weird union errors
             // @ts-expect-error todo(flow->ts)
             type.typeName.escapedText = getFullyQualifiedName(
@@ -633,8 +636,8 @@ export const printType = withEnv<any, [any], string>(
             );
           }
 
-          if (typeof isRenamedOrReplaceWithNode !== "boolean") {
-            return printType(isRenamedOrReplaceWithNode);
+          if (typeof isRenamedOrReplacedNode !== "boolean") {
+            return printType(isRenamedOrReplacedNode);
           }
 
           const getAdjustedType = targetSymbol => {
@@ -835,7 +838,7 @@ export const printType = withEnv<any, [any], string>(
         if (checker.current) {
           //$todo some weird union errors
           const symbol = checker.current.getSymbolAtLocation(type.name);
-          renames(symbol, type);
+          renamesOrReplacesNode(symbol, type);
         }
         return printers.relationships.importExportSpecifier(type);
 

--- a/src/printers/smart-identifiers.ts
+++ b/src/printers/smart-identifiers.ts
@@ -82,10 +82,11 @@ const eventTypes = {
 const reactTypes = {
   ComponentProps: "ElementProps",
   FC: "StatelessFunctionalComponent",
-  // ForwardedRef: "Ref",
 };
 
-export function renames(
+// This function will either rename the node or, if it's React.ForwardedRef<T> it
+// will return a new node containing the type literal {current: T | null}.
+export function renamesOrReplacesNode(
   symbol: ts.Symbol | void,
   type: ts.TypeReferenceNode | ts.ImportSpecifier,
 ): boolean | ts.Node {


### PR DESCRIPTION
## Summary:
We were converting React.ForwardRef<T> to React.Ref<T> which works fine as long as T is a component, but sometimes we need to store an HTML element of some sort.  In those situations, React.Ref<T> doesn't work.  I'm not sure why the Flow team added this restriction to this type.  To workaround this, I've update the Flowgen to output {|current: T | null|} instead.

Issue: None

## Test plan:
- yarn compile
- yarn test